### PR TITLE
feat: n-flex 自 2.37.0 提供该组件。

### DIFF
--- a/src/ui/naiveUi/naiveUi2/flex.json
+++ b/src/ui/naiveUi/naiveUi2/flex.json
@@ -1,0 +1,69 @@
+{
+  "name": "NFlex",
+  "props": {
+    "align": {
+      "value": [
+        "start",
+        "end",
+        "center",
+        "baseline",
+        "stretch"
+      ],
+      "description": "Vertically arranged",
+      "default": "undefined",
+      "type": "start / end / center / baseline / stretch",
+      "description_zh": "垂直排列方式"
+    },
+    "inline": {
+      "value": "",
+      "description": "Whether it is an inline element",
+      "default": "false",
+      "type": "boolean",
+      "description_zh": "是否为行内元素"
+    },
+    "justify": {
+      "value": [
+        "start",
+        "end",
+        "center",
+        "space-around",
+        "space-between",
+        "space-evenly"
+      ],
+      "description": "Arrange it horizontally",
+      "default": "start",
+      "type": "start / end / center / space-around / space-between / space-evenly",
+      "description_zh": "水平排列方式"
+    },
+    "size": {
+      "value": [
+        "small",
+        "medium",
+        "large"
+      ],
+      "description": "When it is a number, it is the horizontal and vertical spacing; For arrays, it is [horizontal spacing, vertical spacing]",
+      "default": "medium",
+      "type": "small / medium / large / number / [number, number]",
+      "description_zh": "为数字时，是水平和垂直间距；为数组时，是 [水平间距, 垂直间距]"
+    },
+    "vertical": {
+      "value": "",
+      "description": "Whether it is vertically laid out",
+      "default": "false",
+      "type": "boolean",
+      "description_zh": "是否垂直布局"
+    },
+    "wrap": {
+      "value": "",
+      "description": "Whether or not to break the line",
+      "default": "true",
+      "type": "boolean",
+      "description_zh": "是否超出换行"
+    }
+  },
+  "methods": [],
+  "typeDetail": {},
+  "events": [],
+  "link": "https://www.naiveui.com/en-US/dark/components/flex",
+  "link_zh": "https://www.naiveui.com/zh-CN/dark/components/flex"
+}

--- a/src/ui/naiveUi/naiveUi2/index.ts
+++ b/src/ui/naiveUi/naiveUi2/index.ts
@@ -33,6 +33,7 @@ import dataTable from './dataTable.json'
 import form from './form.json'
 import formItem from './formItem.json'
 import formItemGi from './formItemGi.json'
+import flex from './flex.json'
 import tabs from './tabs.json'
 import tab from './tab.json'
 import tabPane from './tabPane.json'
@@ -120,6 +121,7 @@ export function naiveUi2() {
     form,
     formItem,
     formItemGi,
+    flex,
     tabs,
     tab,
     tabPane,
@@ -406,6 +408,12 @@ Definitely Maybe
   <n-button>Oops!</n-button>
   <n-button>Long! Long! Cross the line!</n-button>
 </n-space>`],
+        [flex, '弹性布局', `<n-flex>
+  <n-button>Oops!</n-button>
+  <n-button>Oops!</n-button>
+  <n-button>Oops!</n-button>
+  <n-button>Long! Long! Cross the line!</n-button>
+</n-flex>`],
         [spin, '加载', '<n-spin size="small" />'],
         [statistic, '统计数据', '<n-statistic label="统计数据" :value="99"></n-statistic'],
         [steps, '步骤', `<n-steps


### PR DESCRIPTION
naive-ui 官网更新的 n-flex

> n-flex 自 2.37.0 提供该组件。
> https://www.naiveui.com/zh-CN/os-theme/components/flex
> 实话讲用起来和 n-space 差不多，但是能用 n-flex 就不要用 n-space。
> n-flex 使用 flex 布局，其中 gap 属性可能对某些老浏览器兼容性不好。
> n-space 会进行 VNode 级别的操作，可能在某些特殊用例下出现一些渲染问题。